### PR TITLE
Fixes percentage property for TaxRate which should be nullable

### DIFF
--- a/src/Moneybird.Net/Entities/TaxRates/TaxRate.cs
+++ b/src/Moneybird.Net/Entities/TaxRates/TaxRate.cs
@@ -16,7 +16,7 @@ namespace Moneybird.Net.Entities.TaxRates
 
         [JsonPropertyName("percentage")]
         [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
-        public double Percentage { get; set; }
+        public double? Percentage { get; set; }
 
         [JsonPropertyName("tax_rate_type")]
         public TaxRateType TaxRateType { get; set; }

--- a/tests/Moneybird.Net.Tests/Responses/Endpoints/TaxRates/getTaxRates.json
+++ b/tests/Moneybird.Net.Tests/Responses/Endpoints/TaxRates/getTaxRates.json
@@ -34,5 +34,17 @@
     "country": null,
     "created_at": "2022-10-31T08:19:00.645Z",
     "updated_at": "2022-10-31T08:19:00.645Z"
+  },
+  {
+    "id": "370130885305104772",
+    "administration_id": "281289699686381606",
+    "name": "Geen btw",
+    "percentage": null,
+    "tax_rate_type": "sales_invoice",
+    "show_tax": false,
+    "active": true,
+    "country": null,
+    "created_at": "2023-04-10T14:59:44.219Z",
+    "updated_at": "2023-04-10T14:59:44.219Z"
   }
 ]


### PR DESCRIPTION
The percentage within a TaxRate could be null. Without this fix it would crash during deserialization.