### PR TITLE
Add support for customer contact portal endpoints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ The goal is to provide a stable version that has the basic functionality to inte
   - [ ] Assets
   - [x] Contacts
   - [x] Custom fields
-  - [ ] Customer Contact Portal
+  - [x] Customer Contact Portal
   - [x] Document styles
   - [ ] Downloads
   - [ ] Documents: General documents
@@ -41,7 +41,7 @@ The goal is to provide a stable version that has the basic functionality to inte
   - [x] Products
   - [x] Projects
   - [ ] Purchase transactions
-  - [ ] Recurring sales invoices
+  - [x] Recurring sales invoices
   - [ ] Reports
   - [x] Sales invoices (limited)
   - [ ] Subscription templates

--- a/src/Moneybird.Net/Abstractions/IMoneybirdClient.cs
+++ b/src/Moneybird.Net/Abstractions/IMoneybirdClient.cs
@@ -19,6 +19,11 @@ namespace Moneybird.Net.Abstractions
         /// The CustomField Endpoint.
         /// </summary>
         ICustomFieldEndpoint CustomField { get; }
+
+        /// <summary>
+        /// The CustomerContactPortal Endpoint.
+        /// </summary>
+        ICustomerContactPortalEndpoint CustomerContactPortal { get; }
         
         /// <summary>
         /// The DocumentStyle Endpoint.

--- a/src/Moneybird.Net/Endpoints/Abstractions/ICustomerContactPortalEndpoint.cs
+++ b/src/Moneybird.Net/Endpoints/Abstractions/ICustomerContactPortalEndpoint.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using Moneybird.Net.Entities.CustomerContactPortals;
+
+namespace Moneybird.Net.Endpoints.Abstractions
+{
+    public interface ICustomerContactPortalEndpoint
+    {
+        /// <summary>
+        /// Get a temporary link to the customer contact portal.
+        /// </summary>
+        /// <param name="administrationId">The administration id.</param>
+        /// <param name="contactId">The contact id.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <returns>A temporary link to the customer contact portal.</returns>
+        Task<CustomerContactPortalLink> GetTemporaryPortalLinkAsync(string administrationId, string contactId, string accessToken);
+
+        /// <summary>
+        /// Get a temporary link to the invoices page in the customer contact portal.
+        /// </summary>
+        /// <param name="administrationId">The administration id.</param>
+        /// <param name="contactId">The contact id.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <returns>A temporary link to the invoices page.</returns>
+        Task<CustomerContactPortalLink> GetTemporaryInvoicesLinkAsync(string administrationId, string contactId, string accessToken);
+
+        /// <summary>
+        /// Get a temporary link to a subscription page in the customer contact portal.
+        /// </summary>
+        /// <param name="administrationId">The administration id.</param>
+        /// <param name="contactId">The contact id.</param>
+        /// <param name="subscriptionId">The subscription id.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <returns>A temporary link to the subscription page.</returns>
+        Task<CustomerContactPortalLink> GetTemporarySubscriptionLinkAsync(string administrationId, string contactId, string subscriptionId, string accessToken);
+    }
+}

--- a/src/Moneybird.Net/Endpoints/CustomerContactPortalEndpoint.cs
+++ b/src/Moneybird.Net/Endpoints/CustomerContactPortalEndpoint.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using Moneybird.Net.Endpoints.Abstractions;
+using Moneybird.Net.Entities.CustomerContactPortals;
+using Moneybird.Net.Http;
+
+namespace Moneybird.Net.Endpoints
+{
+    public class CustomerContactPortalEndpoint : ICustomerContactPortalEndpoint
+    {
+        private const string CustomerContactPortalUri = "/{0}/customer_contact_portal/{1}.json";
+        private const string CustomerContactPortalInvoicesUri = "/{0}/customer_contact_portal/{1}/invoices.json";
+        private const string CustomerContactPortalSubscriptionsUri = "/{0}/customer_contact_portal/{1}/subscriptions/{2}.json";
+
+        private readonly MoneybirdConfig _config;
+        private readonly IRequester _requester;
+
+        public CustomerContactPortalEndpoint(MoneybirdConfig config, IRequester requester)
+        {
+            _requester = requester;
+            _config = config;
+        }
+
+        public async Task<CustomerContactPortalLink> GetTemporaryPortalLinkAsync(string administrationId, string contactId, string accessToken)
+        {
+            var relativeUrl = string.Format(CustomerContactPortalUri, administrationId, contactId);
+            var responseJson = await _requester
+                .CreateGetRequestAsync(_config.ApiUri, relativeUrl, accessToken)
+                .ConfigureAwait(false);
+
+            return DeserializeCustomerContactPortalLink(responseJson);
+        }
+
+        public async Task<CustomerContactPortalLink> GetTemporaryInvoicesLinkAsync(string administrationId, string contactId, string accessToken)
+        {
+            var relativeUrl = string.Format(CustomerContactPortalInvoicesUri, administrationId, contactId);
+            var responseJson = await _requester
+                .CreateGetRequestAsync(_config.ApiUri, relativeUrl, accessToken)
+                .ConfigureAwait(false);
+
+            return DeserializeCustomerContactPortalLink(responseJson);
+        }
+
+        public async Task<CustomerContactPortalLink> GetTemporarySubscriptionLinkAsync(string administrationId, string contactId, string subscriptionId, string accessToken)
+        {
+            var relativeUrl = string.Format(CustomerContactPortalSubscriptionsUri, administrationId, contactId, subscriptionId);
+            var responseJson = await _requester
+                .CreateGetRequestAsync(_config.ApiUri, relativeUrl, accessToken)
+                .ConfigureAwait(false);
+
+            return DeserializeCustomerContactPortalLink(responseJson);
+        }
+
+        private CustomerContactPortalLink DeserializeCustomerContactPortalLink(string responseJson)
+        {
+            var temporaryLink = JsonSerializer.Deserialize<string>(responseJson, _config.SerializerOptions);
+
+            return new CustomerContactPortalLink
+            {
+                Url = temporaryLink
+            };
+        }
+    }
+}

--- a/src/Moneybird.Net/Entities/CustomerContactPortals/CustomerContactPortalLink.cs
+++ b/src/Moneybird.Net/Entities/CustomerContactPortals/CustomerContactPortalLink.cs
@@ -1,0 +1,7 @@
+namespace Moneybird.Net.Entities.CustomerContactPortals
+{
+    public class CustomerContactPortalLink
+    {
+        public string Url { get; set; }
+    }
+}

--- a/src/Moneybird.Net/MoneybirdClient.cs
+++ b/src/Moneybird.Net/MoneybirdClient.cs
@@ -18,6 +18,7 @@ namespace Moneybird.Net
         public IAdministrationEndpoint Administration { get; }
         public IContactEndpoint Contact { get; }
         public ICustomFieldEndpoint CustomField { get; }
+        public ICustomerContactPortalEndpoint CustomerContactPortal { get; }
         public IDocumentStyleEndpoint DocumentStyle { get; }
         public IExternalSalesInvoiceEndpoint ExternalSalesInvoice { get; }
         public IFinancialAccountEndpoint FinancialAccount { get; }
@@ -65,6 +66,7 @@ namespace Moneybird.Net
             Administration = new AdministrationEndpoint(Config, _requester);
             Contact = new ContactEndpoint(Config, _requester);
             CustomField = new CustomFieldEndpoint(Config, _requester);
+            CustomerContactPortal = new CustomerContactPortalEndpoint(Config, _requester);
             DocumentStyle = new DocumentStyleEndpoint(Config, _requester);
             ExternalSalesInvoice = new ExternalSalesInvoiceEndpoint(Config, _requester);
             FinancialAccount = new FinancialAccountEndpoint(Config, _requester);

--- a/tests/Moneybird.Net.Tests/Endpoints/CustomerContactPortalEndpointTests.cs
+++ b/tests/Moneybird.Net.Tests/Endpoints/CustomerContactPortalEndpointTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moneybird.Net.Endpoints;
+using Moneybird.Net.Entities.CustomerContactPortals;
+using Moneybird.Net.Http;
+using Moq;
+using Xunit;
+
+namespace Moneybird.Net.Tests.Endpoints
+{
+    public class CustomerContactPortalEndpointTests : CustomerContactPortalTestBase
+    {
+        private static Mock<IRequester> _requester;
+        private readonly MoneybirdConfig _config;
+        private readonly CustomerContactPortalEndpoint _customerContactPortalEndpoint;
+
+        private const string GetTemporaryPortalLinkResponsePath = "./Responses/Endpoints/CustomerContactPortal/getTemporaryPortalLink.json";
+        private const string GetTemporaryInvoicesLinkResponsePath = "./Responses/Endpoints/CustomerContactPortal/getTemporaryInvoicesLink.json";
+        private const string GetTemporarySubscriptionLinkResponsePath = "./Responses/Endpoints/CustomerContactPortal/getTemporarySubscriptionLink.json";
+
+        public CustomerContactPortalEndpointTests()
+        {
+            _requester = new Mock<IRequester>();
+            _config = new MoneybirdConfig();
+            _customerContactPortalEndpoint = new CustomerContactPortalEndpoint(_config, _requester.Object);
+        }
+
+        [Fact]
+        public async Task GetTemporaryPortalLinkAsync_ByAccessToken_Returns_TemporaryLink()
+        {
+            var temporaryLinkJson = await File.ReadAllTextAsync(GetTemporaryPortalLinkResponsePath);
+
+            _requester.Setup(moq => moq.CreateGetRequestAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(temporaryLinkJson);
+
+            var temporaryLink = JsonSerializer.Deserialize<string>(temporaryLinkJson, _config.SerializerOptions);
+            Assert.NotNull(temporaryLink);
+
+            var actualTemporaryLink = await _customerContactPortalEndpoint.GetTemporaryPortalLinkAsync(AdministrationId, ContactId, AccessToken);
+            Assert.NotNull(actualTemporaryLink);
+
+            new CustomerContactPortalLink
+            {
+                Url = temporaryLink
+            }.Should().BeEquivalentTo(actualTemporaryLink);
+        }
+
+        [Fact]
+        public async Task GetTemporaryInvoicesLinkAsync_ByAccessToken_Returns_TemporaryLink()
+        {
+            var temporaryLinkJson = await File.ReadAllTextAsync(GetTemporaryInvoicesLinkResponsePath);
+
+            _requester.Setup(moq => moq.CreateGetRequestAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(temporaryLinkJson);
+
+            var temporaryLink = JsonSerializer.Deserialize<string>(temporaryLinkJson, _config.SerializerOptions);
+            Assert.NotNull(temporaryLink);
+
+            var actualTemporaryLink = await _customerContactPortalEndpoint.GetTemporaryInvoicesLinkAsync(AdministrationId, ContactId, AccessToken);
+            Assert.NotNull(actualTemporaryLink);
+
+            new CustomerContactPortalLink
+            {
+                Url = temporaryLink
+            }.Should().BeEquivalentTo(actualTemporaryLink);
+        }
+
+        [Fact]
+        public async Task GetTemporarySubscriptionLinkAsync_ByAccessToken_Returns_TemporaryLink()
+        {
+            var temporaryLinkJson = await File.ReadAllTextAsync(GetTemporarySubscriptionLinkResponsePath);
+
+            _requester.Setup(moq => moq.CreateGetRequestAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<List<string>>())).ReturnsAsync(temporaryLinkJson);
+
+            var temporaryLink = JsonSerializer.Deserialize<string>(temporaryLinkJson, _config.SerializerOptions);
+            Assert.NotNull(temporaryLink);
+
+            var actualTemporaryLink = await _customerContactPortalEndpoint.GetTemporarySubscriptionLinkAsync(AdministrationId, ContactId, SubscriptionId, AccessToken);
+            Assert.NotNull(actualTemporaryLink);
+
+            new CustomerContactPortalLink
+            {
+                Url = temporaryLink
+            }.Should().BeEquivalentTo(actualTemporaryLink);
+        }
+    }
+}

--- a/tests/Moneybird.Net.Tests/Endpoints/CustomerContactPortalTestBase.cs
+++ b/tests/Moneybird.Net.Tests/Endpoints/CustomerContactPortalTestBase.cs
@@ -1,0 +1,7 @@
+namespace Moneybird.Net.Tests.Endpoints
+{
+    public class CustomerContactPortalTestBase : ContactTestBase
+    {
+        protected static string SubscriptionId = "369764595159532558";
+    }
+}

--- a/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporaryInvoicesLink.json
+++ b/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporaryInvoicesLink.json
@@ -1,0 +1,1 @@
+"https://moneybird.com/temporary-link/customer-contact-portal/invoices"

--- a/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporaryPortalLink.json
+++ b/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporaryPortalLink.json
@@ -1,0 +1,1 @@
+"https://moneybird.com/temporary-link/customer-contact-portal"

--- a/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporarySubscriptionLink.json
+++ b/tests/Moneybird.Net.Tests/Responses/Endpoints/CustomerContactPortal/getTemporarySubscriptionLink.json
@@ -1,0 +1,1 @@
+"https://moneybird.com/temporary-link/customer-contact-portal/subscriptions"


### PR DESCRIPTION
## Summary
- Add `ICustomerContactPortalEndpoint` and `CustomerContactPortalEndpoint` with explicit temporary-link methods:
  - `GetTemporaryPortalLinkAsync`
  - `GetTemporaryInvoicesLinkAsync`
  - `GetTemporarySubscriptionLinkAsync`
- Add `CustomerContactPortalLink` entity for the returned temporary URL.
- Wire the endpoint into `IMoneybirdClient` and `MoneybirdClient` via `CustomerContactPortal`.
- Add unit tests and response fixtures for all customer contact portal temporary-link routes.
- Update `ROADMAP.md` to mark Customer Contact Portal and Recurring sales invoices as completed.