### PR TITLE
Prepare for release version 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.24.0 | 2026-08-06
+* Add support for the `Subscriptions` endpoint.
+
 ## 0.23.0 | 2026-07-26
 * Add support for the `Estimates` endpoint.
 * Generalize attachment and tax total entities for invoice and estimate endpoints.

--- a/src/Moneybird.Net/Moneybird.Net.csproj
+++ b/src/Moneybird.Net/Moneybird.Net.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <PackageId>Moneybird.Net</PackageId>
-        <Version>0.23.0</Version>
+        <Version>0.24.0</Version>
         <Authors>Vincent Vrijburg</Authors>
         <Description>A wrapper for the Moneybird API.</Description>
         <Copyright>Copyright © Vincent Vrijburg 2021-2026</Copyright>
@@ -11,7 +11,7 @@
         <PackageTags>dotnet dotnet-core dotnet-standard client wrapper moneybird</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageVersion>0.23.0</PackageVersion>
+        <PackageVersion>0.24.0</PackageVersion>
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- bump package version to 0.24.0
- add changelog entry for 0.24.0 covering the Subscriptions endpoint
