### PR TITLE
Add support for subscription templates endpoint

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@ The goal is to provide a stable version that has the basic functionality to inte
   - [x] Recurring sales invoices
   - [ ] Reports
   - [x] Sales invoices (limited)
-  - [ ] Subscription templates
+  - [x] Subscription templates
   - [x] Subscriptions
   - [ ] Task lists
   - [ ] Task list templates

--- a/src/Moneybird.Net/Abstractions/IMoneybirdClient.cs
+++ b/src/Moneybird.Net/Abstractions/IMoneybirdClient.cs
@@ -99,6 +99,11 @@ namespace Moneybird.Net.Abstractions
         /// The Subscription Endpoint.
         /// </summary>
         ISubscriptionEndpoint Subscription { get; }
+
+        /// <summary>
+        /// The Subscription Template Endpoint.
+        /// </summary>
+        ISubscriptionTemplateEndpoint SubscriptionTemplate { get; }
         
         /// <summary>
         /// The TaxRate Endpoint.

--- a/src/Moneybird.Net/Endpoints/Abstractions/ISubscriptionTemplateEndpoint.cs
+++ b/src/Moneybird.Net/Endpoints/Abstractions/ISubscriptionTemplateEndpoint.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Moneybird.Net.Endpoints.Abstractions.Common;
+using Moneybird.Net.Entities.SubscriptionTemplates;
+using Moneybird.Net.Models.SubscriptionTemplates;
+
+namespace Moneybird.Net.Endpoints.Abstractions;
+
+public interface ISubscriptionTemplateEndpoint : IReadEndpoint<SubscriptionTemplate>
+{
+    Task<SubscriptionTemplateSalesLink> CreateSalesLinkAsync(
+        string administrationId,
+        string id,
+        string accessToken,
+        SubscriptionTemplateSalesLinkOptions options = null);
+}

--- a/src/Moneybird.Net/Endpoints/SubscriptionTemplateEndpoint.cs
+++ b/src/Moneybird.Net/Endpoints/SubscriptionTemplateEndpoint.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Moneybird.Net.Endpoints.Abstractions;
+using Moneybird.Net.Entities.SubscriptionTemplates;
+using Moneybird.Net.Extensions;
+using Moneybird.Net.Http;
+using Moneybird.Net.Models.SubscriptionTemplates;
+
+namespace Moneybird.Net.Endpoints;
+
+public class SubscriptionTemplateEndpoint : ISubscriptionTemplateEndpoint
+{
+    private const string SubscriptionTemplatesUri = "/{0}/subscription_templates.json";
+    private const string SalesLinkUri = "/{0}/subscription_templates/{1}/sales_link.json";
+
+    private readonly MoneybirdConfig _config;
+    private readonly IRequester _requester;
+
+    public SubscriptionTemplateEndpoint(MoneybirdConfig config, IRequester requester)
+    {
+        _config = config;
+        _requester = requester;
+    }
+
+    public async Task<IEnumerable<SubscriptionTemplate>> GetAsync(
+        string administrationId,
+        string accessToken,
+        int page = 1,
+        int perPage = 50)
+    {
+        var parameters = new List<string> { $"page={page}", $"per_page={perPage}" };
+        var response = await _requester
+            .CreateGetRequestAsync(_config.ApiUri, string.Format(SubscriptionTemplatesUri, administrationId), accessToken, parameters)
+            .ConfigureAwait(false);
+
+        return JsonSerializer.Deserialize<IEnumerable<SubscriptionTemplate>>(response, _config.SerializerOptions);
+    }
+
+    public async Task<SubscriptionTemplateSalesLink> CreateSalesLinkAsync(
+        string administrationId,
+        string id,
+        string accessToken,
+        SubscriptionTemplateSalesLinkOptions options = null)
+    {
+        var response = await _requester
+            .CreatePostRequestAsync(_config.ApiUri, string.Format(SalesLinkUri, administrationId, id), accessToken, string.Empty, options.GetQueryParameters())
+            .ConfigureAwait(false);
+
+        return new SubscriptionTemplateSalesLink
+        {
+            Url = JsonSerializer.Deserialize<string>(response, _config.SerializerOptions)
+        };
+    }
+}

--- a/src/Moneybird.Net/Entities/SubscriptionTemplates/SubscriptionTemplate.cs
+++ b/src/Moneybird.Net/Entities/SubscriptionTemplates/SubscriptionTemplate.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Moneybird.Net.Entities.Products;
+
+namespace Moneybird.Net.Entities.SubscriptionTemplates;
+
+public class SubscriptionTemplate : IMoneybirdEntity
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("administration_id")]
+    public string AdministrationId { get; set; }
+
+    [JsonPropertyName("workflow_id")]
+    public string WorkflowId { get; set; }
+
+    [JsonPropertyName("document_style_id")]
+    public string DocumentStyleId { get; set; }
+
+    [JsonPropertyName("mergeable")]
+    public bool Mergeable { get; set; }
+
+    [JsonPropertyName("contact_can_update")]
+    public bool ContactCanUpdate { get; set; }
+
+    [JsonPropertyName("products")]
+    public List<Product> Products { get; set; }
+}

--- a/src/Moneybird.Net/Entities/SubscriptionTemplates/SubscriptionTemplateSalesLink.cs
+++ b/src/Moneybird.Net/Entities/SubscriptionTemplates/SubscriptionTemplateSalesLink.cs
@@ -1,0 +1,6 @@
+namespace Moneybird.Net.Entities.SubscriptionTemplates;
+
+public class SubscriptionTemplateSalesLink
+{
+    public string Url { get; set; }
+}

--- a/src/Moneybird.Net/Extensions/SubscriptionTemplatesExtensions.cs
+++ b/src/Moneybird.Net/Extensions/SubscriptionTemplatesExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Moneybird.Net.Models.SubscriptionTemplates;
 
@@ -17,7 +16,7 @@ internal static class SubscriptionTemplatesExtensions
 
         if (!string.IsNullOrWhiteSpace(options.ContactId))
         {
-            queryParameters.Add($"contact_id={Uri.EscapeDataString(options.ContactId)}");
+            queryParameters.Add($"contact_id={options.ContactId}");
         }
 
         if (options.StartDate.HasValue)
@@ -27,7 +26,7 @@ internal static class SubscriptionTemplatesExtensions
 
         if (!string.IsNullOrWhiteSpace(options.ProductId))
         {
-            queryParameters.Add($"product_id={Uri.EscapeDataString(options.ProductId)}");
+            queryParameters.Add($"product_id={options.ProductId}");
         }
 
         return queryParameters.Count > 0 ? queryParameters : null;

--- a/src/Moneybird.Net/Extensions/SubscriptionTemplatesExtensions.cs
+++ b/src/Moneybird.Net/Extensions/SubscriptionTemplatesExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Moneybird.Net.Models.SubscriptionTemplates;
+
+namespace Moneybird.Net.Extensions;
+
+internal static class SubscriptionTemplatesExtensions
+{
+    public static List<string> GetQueryParameters(this SubscriptionTemplateSalesLinkOptions options)
+    {
+        if (options == null)
+        {
+            return null;
+        }
+
+        var queryParameters = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(options.ContactId))
+        {
+            queryParameters.Add($"contact_id={Uri.EscapeDataString(options.ContactId)}");
+        }
+
+        if (options.StartDate.HasValue)
+        {
+            queryParameters.Add($"start_date={options.StartDate.Value:yyyy-MM-dd}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ProductId))
+        {
+            queryParameters.Add($"product_id={Uri.EscapeDataString(options.ProductId)}");
+        }
+
+        return queryParameters.Count > 0 ? queryParameters : null;
+    }
+}

--- a/src/Moneybird.Net/Models/SubscriptionTemplates/SubscriptionTemplateSalesLinkOptions.cs
+++ b/src/Moneybird.Net/Models/SubscriptionTemplates/SubscriptionTemplateSalesLinkOptions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Moneybird.Net.Models.SubscriptionTemplates;
+
+public class SubscriptionTemplateSalesLinkOptions
+{
+    public string ContactId { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public string ProductId { get; set; }
+}

--- a/src/Moneybird.Net/MoneybirdClient.cs
+++ b/src/Moneybird.Net/MoneybirdClient.cs
@@ -35,6 +35,7 @@ namespace Moneybird.Net
         public IRecurringSalesInvoiceEndpoint RecurringSalesInvoice { get; }
         public ISalesInvoiceEndpoint SalesInvoice { get; }
         public ISubscriptionEndpoint Subscription { get; }
+        public ISubscriptionTemplateEndpoint SubscriptionTemplate { get; }
         public ITaxRateEndpoint TaxRate { get; }
         public ITimeEntryEndpoint TimeEntry { get; }
         public IUserEndpoint User { get; }
@@ -88,6 +89,7 @@ namespace Moneybird.Net
             RecurringSalesInvoice = new RecurringSalesInvoiceEndpoint(Config, _requester);
             SalesInvoice = new SalesInvoiceEndpoint(Config, _requester);
             Subscription = new SubscriptionEndpoint(Config, _requester);
+            SubscriptionTemplate = new SubscriptionTemplateEndpoint(Config, _requester);
             TaxRate = new TaxRateEndpoint(Config, _requester);
             TimeEntry = new TimeEntryEndpoint(Config, _requester);
             User = new UserEndpoint(Config, _requester);

--- a/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
+++ b/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moneybird.Net.Endpoints;
+using Moneybird.Net.Http;
+using Moneybird.Net.Misc;
+using Moneybird.Net.Models.SubscriptionTemplates;
+using Moq;
+using Xunit;
+
+namespace Moneybird.Net.Tests.Endpoints;
+
+public class SubscriptionTemplateEndpointTests : CommonTestBase
+{
+    private const string TemplateId = "494722488146593096";
+    private const string ResponsePath = "./Responses/Endpoints/SubscriptionTemplates/getSubscriptionTemplates.json";
+    private const string SalesLinkResponse = "\"https://checkout.moneybird.com/o/PLD9QPK5DV85\"";
+
+    private readonly Mock<IRequester> _requester = new();
+    private readonly MoneybirdConfig _config = new();
+    private readonly SubscriptionTemplateEndpoint _endpoint;
+
+    public SubscriptionTemplateEndpointTests()
+    {
+        _endpoint = new SubscriptionTemplateEndpoint(_config, _requester.Object);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsSubscriptionTemplatesAndIncludesPagination()
+    {
+        var json = await File.ReadAllTextAsync(ResponsePath);
+        string relativeUrl = null;
+        List<string> query = null;
+        _requester
+            .Setup(requester => requester.CreateGetRequestAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken, It.IsAny<List<string>>()))
+            .Callback<string, string, string, List<string>>((_, url, _, values) =>
+            {
+                relativeUrl = url;
+                query = values;
+            })
+            .ReturnsAsync(json);
+
+        var result = (await _endpoint.GetAsync(AdministrationId, AccessToken, 2, 100)).Single();
+
+        relativeUrl.Should().Be($"/{AdministrationId}/subscription_templates.json");
+        query.Should().BeEquivalentTo(new[] { "page=2", "per_page=100" });
+        result.Id.Should().Be(TemplateId);
+        result.AdministrationId.Should().Be(AdministrationId);
+        result.WorkflowId.Should().Be("494722488131913026");
+        result.DocumentStyleId.Should().Be("494722369162577049");
+        result.Mergeable.Should().BeFalse();
+        result.ContactCanUpdate.Should().BeTrue();
+
+        var product = result.Products.Single();
+        product.AdministrationId.Should().Be(AdministrationId);
+        product.Title.Should().BeNull();
+        product.Identifier.Should().BeNull();
+        product.Price.Should().Be(10);
+        product.Frequency.Should().Be(1);
+        product.FrequencyType.Should().Be(FrequencyType.Month);
+        product.CreatedAt.Should().Be(new DateTime(2026, 8, 6, 13, 49, 12, 409, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task CreateSalesLinkAsync_SendsOptionsAsQueryAndReturnsLink()
+    {
+        string relativeUrl = null;
+        string body = null;
+        List<string> query = null;
+        _requester
+            .Setup(requester => requester.CreatePostRequestAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                AccessToken,
+                It.IsAny<string>(),
+                It.IsAny<List<string>>()))
+            .Callback<string, string, string, string, List<string>>((_, url, _, content, values) =>
+            {
+                relativeUrl = url;
+                body = content;
+                query = values;
+            })
+            .ReturnsAsync(SalesLinkResponse);
+
+        var options = new SubscriptionTemplateSalesLinkOptions
+        {
+            ContactId = "123 456",
+            StartDate = new DateTime(2026, 8, 15),
+            ProductId = "789"
+        };
+
+        var result = await _endpoint.CreateSalesLinkAsync(AdministrationId, TemplateId, AccessToken, options);
+
+        relativeUrl.Should().Be($"/{AdministrationId}/subscription_templates/{TemplateId}/sales_link.json");
+        body.Should().BeEmpty();
+        query.Should().Equal("contact_id=123%20456", "start_date=2026-08-15", "product_id=789");
+        result.Url.Should().Be("https://checkout.moneybird.com/o/PLD9QPK5DV85");
+    }
+
+}

--- a/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
+++ b/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
@@ -71,12 +71,7 @@ public class SubscriptionTemplateEndpointTests : CommonTestBase
         string body = null;
         List<string> query = null;
         _requester
-            .Setup(requester => requester.CreatePostRequestAsync(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                AccessToken,
-                It.IsAny<string>(),
-                It.IsAny<List<string>>()))
+            .Setup(requester => requester.CreatePostRequestAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken, It.IsAny<string>(), It.IsAny<List<string>>()))
             .Callback<string, string, string, string, List<string>>((_, url, _, content, values) =>
             {
                 relativeUrl = url;

--- a/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
+++ b/tests/Moneybird.Net.Tests/Endpoints/SubscriptionTemplateEndpointTests.cs
@@ -96,7 +96,7 @@ public class SubscriptionTemplateEndpointTests : CommonTestBase
 
         relativeUrl.Should().Be($"/{AdministrationId}/subscription_templates/{TemplateId}/sales_link.json");
         body.Should().BeEmpty();
-        query.Should().Equal("contact_id=123%20456", "start_date=2026-08-15", "product_id=789");
+        query.Should().Equal("contact_id=123 456", "start_date=2026-08-15", "product_id=789");
         result.Url.Should().Be("https://checkout.moneybird.com/o/PLD9QPK5DV85");
     }
 

--- a/tests/Moneybird.Net.Tests/Extensions/SubscriptionTemplatesExtensionsTests.cs
+++ b/tests/Moneybird.Net.Tests/Extensions/SubscriptionTemplatesExtensionsTests.cs
@@ -1,0 +1,47 @@
+using System;
+using Moneybird.Net.Extensions;
+using Moneybird.Net.Models.SubscriptionTemplates;
+using Xunit;
+
+namespace Moneybird.Net.Tests.Extensions;
+
+public class SubscriptionTemplatesExtensionsTests
+{
+    [Fact]
+    public void GetQueryParameters_FromNullOptions_Returns_Null()
+    {
+        SubscriptionTemplateSalesLinkOptions options = null;
+
+        var actualParameters = options.GetQueryParameters();
+
+        Assert.Null(actualParameters);
+    }
+
+    [Fact]
+    public void GetQueryParameters_FromEmptyOptions_Returns_Null()
+    {
+        var options = new SubscriptionTemplateSalesLinkOptions();
+
+        var actualParameters = options.GetQueryParameters();
+
+        Assert.Null(actualParameters);
+    }
+
+    [Fact]
+    public void GetQueryParameters_FromAllOptions_Returns_CorrectValues()
+    {
+        var options = new SubscriptionTemplateSalesLinkOptions
+        {
+            ContactId = "123 456",
+            StartDate = new DateTime(2026, 8, 15),
+            ProductId = "789"
+        };
+
+        var actualParameters = options.GetQueryParameters();
+
+        Assert.Equal(3, actualParameters.Count);
+        Assert.Equal("contact_id=123 456", actualParameters[0]);
+        Assert.Equal("start_date=2026-08-15", actualParameters[1]);
+        Assert.Equal("product_id=789", actualParameters[2]);
+    }
+}

--- a/tests/Moneybird.Net.Tests/MoneybirdClientTests.cs
+++ b/tests/Moneybird.Net.Tests/MoneybirdClientTests.cs
@@ -32,6 +32,7 @@ namespace Moneybird.Net.Tests
             Assert.NotNull(moneybirdClient.RecurringSalesInvoice);
             Assert.NotNull(moneybirdClient.SalesInvoice);
             Assert.NotNull(moneybirdClient.Subscription);
+            Assert.NotNull(moneybirdClient.SubscriptionTemplate);
             Assert.NotNull(moneybirdClient.TaxRate);
             Assert.NotNull(moneybirdClient.TimeEntry);
             Assert.NotNull(moneybirdClient.User);

--- a/tests/Moneybird.Net.Tests/Responses/Endpoints/SubscriptionTemplates/getSubscriptionTemplates.json
+++ b/tests/Moneybird.Net.Tests/Responses/Endpoints/SubscriptionTemplates/getSubscriptionTemplates.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "494722488146593096",
+    "administration_id": "281289699686381606",
+    "workflow_id": "494722488131913026",
+    "document_style_id": "494722369162577049",
+    "mergeable": false,
+    "contact_can_update": true,
+    "products": [
+      {
+        "id": "494722488141350215",
+        "administration_id": "281289699686381606",
+        "description": "fancy product",
+        "title": null,
+        "identifier": null,
+        "price": "10.0",
+        "currency": "EUR",
+        "frequency": 1,
+        "frequency_type": "month",
+        "tax_rate_id": "494722368519799946",
+        "ledger_account_id": "494722368310084730",
+        "created_at": "2026-08-06T13:49:12.409Z",
+        "updated_at": "2026-08-06T13:49:12.409Z"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Implements support for the [Moneybird Subscription Templates API](https://developer.moneybird.com/api/subscription-templates).

## Changes

### New endpoint
- `ISubscriptionTemplateEndpoint` — interface with the subscription template endpoint contract
- `SubscriptionTemplateEndpoint` — implementation of subscription template operations
- Wired into `IMoneybirdClient` and `MoneybirdClient`

### Supported operations
| Method | Description |
|---|---|
| `GetAsync` | List subscription templates with pagination |
| `CreateSalesLinkAsync` | Create a temporary sales link, optionally prefilled with a contact, start date, and product |

### New models & entities
- `SubscriptionTemplate`, `SubscriptionTemplateSalesLink`
- `SubscriptionTemplateSalesLinkOptions`

### Other
- Added fixture-based endpoint tests covering template retrieval and sales-link creation
- Added a response fixture based on the official API example
- Marked **Subscription templates** as done in `ROADMAP.md`